### PR TITLE
修复 \mathcal 花体显示过于卷曲的问题，优化数学字体配置

### DIFF
--- a/src/mynudt.sty
+++ b/src/mynudt.sty
@@ -12,8 +12,10 @@
 \RequirePackage{array} % 支持表格中的多行文本
 \RequirePackage{makecell} % 支持表格中的多行文本
 \RequirePackage[T1]{fontenc}  % 使用T1编码支持更好的字体渲染
-\RequirePackage{mathptmx}  % 将数学字体设置为Times New Roman
-\RequirePackage{amsmath}   % 提供更多的数学环境和命令
+% \RequirePackage{mathptmx}  % 将数学字体设置为Times New Roman
+% \RequirePackage{amsmath}   % 提供更多的数学环境和命令
+\RequirePackage{amsmath,amssymb,bm} % 整合了数学环境、符号和粗体
+\RequirePackage{txfonts}            % 替换掉 mathptmx，解决花体 L 过于卷曲的问题
 % \RequirePackage{algorithmicx}
 % \RequirePackage{algpseudocode} 
 


### PR DESCRIPTION
目前的模板在使用 \mathcal 命令（如表示 Loss 函数 $\mathcal{L}$）时，由于加载了较老旧的 mathptmx 宏包，导致花体字母显示为极其卷曲的 Zapf Chancery 手写字体（类似 \mathrsfs 的效果）。修改后，\mathcal{L} 将恢复为标准、端庄的数学花体（Calligraphic），不再过于卷曲。