### PR TITLE
修改\mathcal{}字体

### DIFF
--- a/src/mynudt.sty
+++ b/src/mynudt.sty
@@ -14,6 +14,7 @@
 \RequirePackage[T1]{fontenc}  % 使用T1编码支持更好的字体渲染
 \RequirePackage{mathptmx}  % 将数学字体设置为Times New Roman
 \RequirePackage{amsmath}   % 提供更多的数学环境和命令
+\DeclareMathAlphabet{\mathcal}{OMS}{cmsy}{m}{n}  % 恢复标准的 calligraphic 字体
 % \RequirePackage{algorithmicx}
 % \RequirePackage{algpseudocode} 
 


### PR DESCRIPTION
目前的模板在使用 \mathcal 命令（如表示 Loss 函数 $\mathcal{L}$）时，由于加载了较老旧的 mathptmx 宏包，导致花体字母显示为极其卷曲的 Zapf Chancery 手写字体（类似 \mathrsfs 的效果）。在加载 mathptmx 后重新定义 \mathcal 字体族